### PR TITLE
Fix(#12): Deleted push relations for entities

### DIFF
--- a/src/environment/environment.service.ts
+++ b/src/environment/environment.service.ts
@@ -27,16 +27,6 @@ export class EnvironmentService extends ABACService<EnvironmentDocument> {
     super(PrivilegeDomain.ENVS, envModel);
   }
 
-  async internal_addProjectToEnv(
-    envId: string,
-    project: ProjectDocument,
-  ): Promise<void> {
-    await this.envModel.updateOne(
-      { id: envId },
-      { $push: { projects: project } },
-    );
-  }
-
   async internal_getEnvs(
     id?: string,
   ): Promise<EnvironmentDocument[] | EnvironmentDocument> {

--- a/src/project/project.module.ts
+++ b/src/project/project.module.ts
@@ -6,6 +6,7 @@ import { Project, ProjectSchema } from './models/project.model';
 import { EnvironmentModule } from 'src/environment/environment.module';
 import { OperatorModule } from 'src/operator/operator.module';
 import { PrivilegeModule } from 'src/privilege/privilege.module';
+import { VariableModule } from 'src/variable/variable.module';
 
 @Module({
   imports: [
@@ -16,11 +17,12 @@ import { PrivilegeModule } from 'src/privilege/privilege.module';
       },
     ]),
     forwardRef(() => EnvironmentModule),
+    forwardRef(() => VariableModule),
     OperatorModule,
     PrivilegeModule,
   ],
   providers: [ProjectService],
-  controllers: [ProjectController],
   exports: [ProjectService],
+  controllers: [ProjectController],
 })
 export class ProjectModule {}

--- a/src/variable/variable.module.ts
+++ b/src/variable/variable.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { VariableService } from './variable.service';
 import { VariableController } from './variable.controller';
 import { MongooseModule } from '@nestjs/mongoose';
@@ -14,10 +14,11 @@ import { PrivilegeModule } from 'src/privilege/privilege.module';
         name: Variable.name,
       },
     ]),
-    ProjectModule,
+    forwardRef(() => ProjectModule),
     PrivilegeModule,
   ],
   providers: [VariableService],
+  exports: [VariableService],
   controllers: [VariableController],
 })
 export class VariableModule {}


### PR DESCRIPTION
Deleted the push relations between entities because it is causing complexity when deleting relations.
Now when a project is deleted the variables of the project are deleted too.